### PR TITLE
shellbin.v | Update method

### DIFF
--- a/shellbin.v
+++ b/shellbin.v
@@ -1,26 +1,24 @@
-import os
 import json
 import net.http
 
 fn http_request(method, xdata string) string {
-        xreq := http.Request{
-                method: method
-                headers: {
-                        'Content-Type': 'application/json'
-                }
-                cookies: map[string]string{}
-                data: xdata
-                url: 'https://shellbin-api.nextblu.com/api/v1/bin/new'
-                user_agent: ''
-                verbose: false
-                user_ptr: 0
-                ws_func: 0
-        }
-        result := xreq.do() or {
-                println('\x1B[31mThe server is offline or this client is outdated. Failed to create the bin.\033[0m\t\t')
-                return 'error'
-        }
-        return result.text.replace('"', '')
+	xreq := http.Request{
+		method: http.method_from_str(method)
+		headers: {
+			'Content-Type': 'application/json'
+		}
+		data: xdata
+		url: 'https://shellbin-api.nextblu.com/api/v1/bin/new'
+		user_agent: ''
+		verbose: false
+		user_ptr: 0
+		ws_func: 0
+	}
+	result := xreq.do() or {
+		println('\x1B[31mThe server is offline or this client is outdated. Failed to create the bin.\033[0m\t\t')
+		return 'error'
+	}
+	return result.text.replace('"', '')
 }
 
 fn get_shellbin_lines() string {
@@ -45,7 +43,7 @@ fn get_shellbin_lines() string {
 				}
 			} else {
 				line = line.trim_space()
-				inputstr += '\n'+line
+				inputstr += '\n' + line
 				blank_lines_count = 0
 			}
 		}
@@ -56,22 +54,22 @@ fn get_shellbin_lines() string {
 				break
 			}
 			line = line.trim_space()
-			inputstr += '\n'+line
+			inputstr += '\n' + line
 		}
-		return inputstr
 	}
+	return inputstr
 }
 
 fn main() {
-        // array to hold data read from stdin
+	// array to hold data read from stdin
 	mut data := get_shellbin_lines()
 	mut encoded_data := json.encode(data)
 	// Sending data to the endpoint
 	mut http_result := http_request('POST', encoded_data)
 	if http_result != 'error' {
-			println('\x1B[36m ShellBin\033[0m v1.0.6')
-			println('Here is your bin: https://shellbin.nextblu.com/#/$http_result')
+		println('\x1B[36m ShellBin\033[0m v1.0.6')
+		println('Here is your bin: https://shellbin.nextblu.com/#/$http_result')
 	} else {
-			println('The server may be down. Please check the status at https://status.nextblu.com/')
+		println('The server may be down. Please check the status at https://status.nextblu.com/')
 	}
 }


### PR DESCRIPTION
as V now handles all of the http.Method values in .str() so I changed method to http.method_from_str(method) in line 5

And also, I noticed we have to make sure cmd is in 'chcp 65001' (utf-8) if it's not your default value. (Koreans use 949, so it gave me an error when passing 'dir | shellbin')

Because cJSON encodes in UTF-8

Here's my sample result : https://shellbin.nextblu.com/#/AW7QFS2VOS

(also v fmt)